### PR TITLE
I fixed compile error on gcc version 4.6.3

### DIFF
--- a/ngx_http_auth_digest_module.c
+++ b/ngx_http_auth_digest_module.c
@@ -320,6 +320,8 @@ ngx_http_auth_digest_decode_auth(ngx_http_request_t *r, ngx_str_t *auth_str, cha
     field_val->data = ngx_pcalloc(r->pool, field_val->len);
     p = ngx_cpymem(field_val->data, start, last-start);
   }
+
+  p=p;
   
   return 0;
 }


### PR DESCRIPTION
I fixed compile error on gcc version 4.6.3. In function ngx_http_auth_digest_decode_auth, It cause unused-but-set-variable warning and it caused compile error.

I added p=p; to solve this problem.
