### PR TITLE
Update ngx_http_auth_digest_module.h

### DIFF
--- a/ngx_http_auth_digest_module.h
+++ b/ngx_http_auth_digest_module.h
@@ -50,7 +50,7 @@ typedef struct {
   ngx_rbtree_node_t node; // the node's .key is derived from the source address
   time_t drop_time;
   ngx_int_t failcount;
-  struct sockaddr src_addr;
+  struct sockaddr_storage src_addr;
   socklen_t src_addrlen;
 } ngx_http_auth_digest_ev_node_t;
 


### PR DESCRIPTION
We discovered a bug with IPv6 authentication: the ngx_memcpy() in the function ngx_http_auth_digest_evasion_tracking() causes a segmentation fault because node.src_addr is defined as struct sockaddr, that is too small to contain a struct sockaddr_in6.
It must be defined as struct sockaddr_storage.