### PR TITLE
Don't allow logins from other realms

### DIFF
--- a/ngx_http_auth_digest_module.c
+++ b/ngx_http_auth_digest_module.c
@@ -174,6 +174,10 @@ static ngx_int_t ngx_http_auth_digest_handler(ngx_http_request_t *r) {
     return NGX_HTTP_INTERNAL_SERVER_ERROR;
   }
 
+  if (ngx_strncmp(realm.data, auth_fields->realm.data, ngx_min(realm.len, auth_fields->realm.len)) != 0) {
+    return ngx_http_auth_digest_send_challenge(r, &realm, 0);
+  }
+
   // check for the existence of a passwd file and attempt to open it
   if (ngx_http_complex_value(r, &alcf->user_file, &user_file) != NGX_OK) {
     return NGX_ERROR;
@@ -648,15 +652,15 @@ ngx_http_auth_digest_verify_hash(ngx_http_request_t *r,
   // - Otherwise the check is not executed and authorization is declined
   if (!((r->unparsed_uri.len == fields->uri.len) &&
         (ngx_strncmp(r->unparsed_uri.data, fields->uri.data, fields->uri.len) == 0)))
-  { 
+  {
     if (!((r->unparsed_uri.len > fields->uri.len) &&
           (ngx_strncmp(r->unparsed_uri.data, fields->uri.data, fields->uri.len) == 0) &&
           (r->unparsed_uri.data[fields->uri.len] == '?')))
     {
-      return NGX_DECLINED; 
+      return NGX_DECLINED;
     }
   }
-  
+
   //  the hashing scheme:
   //    digest:
   //    MD5(MD5(username:realm:password):nonce:nc:cnonce:qop:MD5(method:uri))

--- a/readme.rst
+++ b/readme.rst
@@ -114,6 +114,7 @@ auth_digest_user_file
   included `htdigest.py`_ script). Each line of the file is a colon-separated list composed 
   of a username, realm, and md5 hash combining name, realm, and password. For example:
   ``joi:enfield:ef25e85b34208c246cfd09ab76b01db7``
+  This file needs to be readable by your nginx user!
   
 auth_digest_timeout
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Allow users to have different passwords for different realms. Before this change any password from another realm for the same user would be accepted.

I'm just going to leave the other commit in there as well, it was accidental, I had no idea that difference between these forks still existed and it's good to make them the same.