### PR TITLE
"Work around" for IPv6 Crash and Evasion Tracking issues

### DIFF
--- a/ngx_http_auth_digest_module.c
+++ b/ngx_http_auth_digest_module.c
@@ -283,15 +283,15 @@ static ngx_int_t ngx_http_auth_digest_handler(ngx_http_request_t *r) {
 
   // log only wrong username/password,
   // not expired hash
+  // also don't activate evasion tracking unnecessarily
   int nc = ngx_hextoi(auth_fields->nc.data, auth_fields->nc.len);
   if (nc == 1) {
     ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
                   "invalid username or password for %*s",
                   auth_fields->username.len, auth_fields->username.data);
+    ngx_http_auth_digest_evasion_tracking(r, alcf,
+        NGX_HTTP_AUTH_DIGEST_STATUS_FAILURE);
   }
-
-  ngx_http_auth_digest_evasion_tracking(r, alcf,
-                                        NGX_HTTP_AUTH_DIGEST_STATUS_FAILURE);
 
   // since no match was found based on the fields in the authorization header,
   // send a new challenge and let the client retry

--- a/ngx_http_auth_digest_module.h
+++ b/ngx_http_auth_digest_module.h
@@ -132,6 +132,7 @@ ngx_http_auth_digest_ev_rbtree_find(ngx_http_auth_digest_ev_node_t *this,
                                     ngx_rbtree_node_t *sentinel);
 #define NGX_HTTP_AUTH_DIGEST_STATUS_SUCCESS 1
 #define NGX_HTTP_AUTH_DIGEST_STATUS_FAILURE 0
+static size_t ngx_http_auth_digest_get_copy_size(size_t source_size, size_t dest_size);
 static void
 ngx_http_auth_digest_evasion_tracking(ngx_http_request_t *r,
                                       ngx_http_auth_digest_loc_conf_t *alcf,


### PR DESCRIPTION
"Work around" for IPv6 Crash:
Opened the issue for the IPv6 Crash here https://github.com/samizdatco/nginx-http-auth-digest/issues/38.

Evasion Tracking:
Only activate evasion tracking during failed username/password and not for requests without auth header or hash expired, else there's high probability it will end up in evasion period when a browser sends lots of requests at once.