### PR TITLE
If the nonce value in the request header is not found in the digest tree, set stale in the response header to 1. 

### DIFF
--- a/ngx_http_auth_digest_module.c
+++ b/ngx_http_auth_digest_module.c
@@ -836,8 +836,9 @@ ngx_http_auth_digest_verify_hash(ngx_http_request_t *r,
     info_header->hash = 1;
     return NGX_OK;
   } else {
-  // nonce is invalid/expired.
-  fields->stale = 1;
+    // Set the stale value to 1 because the nonce value was not found in 
+    // the digest tree, but the computation is valid.
+    fields->stale = 1;
   
   invalid:
     // nonce is invalid/expired or client reused an nc value. suspicious...

--- a/ngx_http_auth_digest_module.c
+++ b/ngx_http_auth_digest_module.c
@@ -836,6 +836,9 @@ ngx_http_auth_digest_verify_hash(ngx_http_request_t *r,
     info_header->hash = 1;
     return NGX_OK;
   } else {
+  // nonce is invalid/expired.
+  fields->stale = 1;
+  
   invalid:
     // nonce is invalid/expired or client reused an nc value. suspicious...
     ngx_shmtx_unlock(&shpool->mutex);


### PR DESCRIPTION
The RFC2617 document says the following.

```
The server should only set stale to TRUE
 if it receives a request for which the nonce is invalid but with a
 valid digest for that nonce (indicating that the client knows the
 correct username/password).
```

This means that even if the digest structure is not found in the ngx_http_auth_digest_rbtree, the response header needs to have the stale value set to 1 if the response value computed based on the nonce value contained in the request header matches.

please check this. :)